### PR TITLE
Updated the example in colorToHex

### DIFF
--- a/src/Color/Convert.elm
+++ b/src/Color/Convert.elm
@@ -138,7 +138,7 @@ hexToColor c =
 {-|
 Converts a color to a hexadecimal string.
 
-    hexToColor (rgb 255 0 0) -- "#ff0000"
+    colorToHex (rgb 255 0 0) -- "#ff0000"
 
 -}
 colorToHex : Color -> String


### PR DESCRIPTION
The `colorToHex` example code used `hexToColor` instead. I've just updated the comment to use the `colorToHex` function.