### PR TITLE
Fix maximum contrast documentation

### DIFF
--- a/src/Color/Accessibility.elm
+++ b/src/Color/Accessibility.elm
@@ -65,10 +65,10 @@ luminance cl =
 {-|
 Returns the color with the highest contrast to the base color.
 
-bgColor = Color.darkBlue
-textOptions = [Color.white, Color.purple, Color.black]
+    bgColor = Color.darkBlue
+    textOptions = [ Color.white, Color.purple, Color.black ]
 
-    maximumContrast bgColor textOptions -- Color.white
+    maximumContrast bgColor textOptions -- Just Color.white
 -}
 maximumContrast : Color -> List Color -> Maybe Color
 maximumContrast base options =


### PR DESCRIPTION
Hey, just a minor thing but I noticed after you published #15 that the documentation wasn't formatted right for contrast ratio: http://package.elm-lang.org/packages/eskimoblood/elm-color-extra/4.1.0/Color-Accessibility#maximumContrast